### PR TITLE
Removing `gcc` package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,10 @@ env:
 
 
 before_install:
+    # Remove homebrew.
     - brew remove --force $(brew list)
+    - brew cleanup -s
+    - rm -rf $(brew --cache)
 
 install:
     - |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 089155b2d864a6dca0f30491da0ed4fc
 
 build:
-  number: 0
+  number: 3
   skip: true  # [win]
 
 requirements:
@@ -23,7 +23,6 @@ requirements:
   - bob.io.base
   - libmatio
   - pkg-config
-  - gcc     # [linux]
 
   run:
   - python
@@ -32,7 +31,6 @@ requirements:
   - bob.core
   - bob.io.base
   - libmatio
-  - libgcc  # [linux]
 
 test:
   imports:


### PR DESCRIPTION
We now have a C++11 capable `gcc` compiler in the docker image. It would be nice if you could do the following to try this.
1. Fork this repo.
2. Create a new branch
3. Remove `gcc` and `libgcc`.
4. Add, commit, push to your fork.
5. Open a PR to remove them.
6. Note in the PR that this issue is fixed by it.

Please ping me when you have done these things.
